### PR TITLE
made the chart responsive on sm,md,lg screen sizes

### DIFF
--- a/frontend/src/components/DashboardMain.js
+++ b/frontend/src/components/DashboardMain.js
@@ -27,14 +27,11 @@ const DashboardMain = () => {
     }
   };
   return (
-    <div className="DashMainApp" class="h-screen relative">
+    <div className="DashMainApp h-screen relative">
       <ResponsiveNavigation active={active} setActive={setActive} user={user} />
-      <div className="mainAppLayout" class="p-8 h-full flex gap-8">
+      <div className="mainAppLayout p-4 h-full flex gap-3">
         {/* <Navigation active={active} setActive={setActive} user={user} /> */}
-        <main
-          class="flex-1 bg-rgba-252-246-249-78 border-3 border-white backdrop-blur-4.5 rounded-2xl overflow-x-hidden
-"
-        >
+        <main className="flex-1 bg-rgba-252-246-249-78 border-3 border-white backdrop-blur-4.5 rounded-2xl overflow-x-hidden">
           {renderComponent()}
         </main>
       </div>

--- a/frontend/src/components/DashboardNav/FinancesOverview.js
+++ b/frontend/src/components/DashboardNav/FinancesOverview.js
@@ -28,7 +28,7 @@ function FinanceOverview() {
     <InnerLayout>
       <h1>All Transactions</h1>
       <div class="flex flex-wrap">
-        <div class="w-full md:w-1/2 px-4">
+        <div class="w-full md:w-full sm:w-full lg:w-1/2 px-4">
           <div class="chart-con">
             <FinanceChart />
           </div>

--- a/frontend/src/components/DashboardNav/Items/Chart.js
+++ b/frontend/src/components/DashboardNav/Items/Chart.js
@@ -59,10 +59,14 @@ function FinanceChart() {
       },
     ],
   };
+  const options = {
+    responsive: true,
+    maintainAspectRatio: true,
+  };
 
   return (
-    <div className="chart-container" style={{}}>
-      <Line data={data} />
+    <div className="chart-container" style={{ width: "100%", height: "100%" }}>
+      <Line data={data} options={options} />
     </div>
   );
 }


### PR DESCRIPTION
**Description**

- Added responsive design to the financial overview chart to accommodate different screen sizes
- See pictures below for reference of the design: 

**Desktop View** 
<img width="1425" alt="Screen Shot 2023-04-22 at 12 40 57 PM" src="https://user-images.githubusercontent.com/90358616/233796386-4e31d761-79a4-40e9-85ce-e6a56d88a220.png">

**Mobile View**
<img width="369" alt="Screen Shot 2023-04-22 at 12 41 35 PM" src="https://user-images.githubusercontent.com/90358616/233796414-5633fe5f-a04d-4762-a7c4-810104523b0e.png">

**Medium Size View**
<img width="516" alt="Screen Shot 2023-04-22 at 12 42 20 PM" src="https://user-images.githubusercontent.com/90358616/233796432-4efdfaeb-0075-4f97-a57e-14697b27ae22.png">


